### PR TITLE
Try to use the best backend (SWING/XTERM) by default

### DIFF
--- a/src/jexer/TApplication.java
+++ b/src/jexer/TApplication.java
@@ -28,6 +28,7 @@
  */
 package jexer;
 
+import java.awt.GraphicsEnvironment;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -546,15 +547,44 @@ public class TApplication implements Runnable {
 
     /**
      * Public constructor.
+     * <p>
+     * Will use the "best" {@link BackendType} it can assume:
+     * <ul>
+     * <li>SWING if the system property <tt>jexer.Swing</tt> is "true"</li>
+     * <li>SWING on MS-Windows</li>
+     * <li>SWING if no console can be found</li>
+     * <li>XTERM in all the other cases</li>
+     * </ul>
+     *
+     * @throws UnsupportedEncodingException if an exception is thrown when
+     * creating the InputStreamReader
+     */
+    public TApplication() throws UnsupportedEncodingException {
+    	this((BackendType)null);
+    }
+    
+    /**
+     * Public constructor.
      *
      * @param backendType BackendType.XTERM, BackendType.ECMA48 or
      * BackendType.SWING
      * @throws UnsupportedEncodingException if an exception is thrown when
      * creating the InputStreamReader
      */
-    public TApplication(final BackendType backendType)
+    public TApplication(BackendType backendType)
         throws UnsupportedEncodingException {
 
+    	if (backendType == null) {
+    		boolean isMsWindows = System.getProperty("os.name", "").toLowerCase().startsWith("windows");
+    		boolean forceSwing = System.getProperty("jexer.Swing", "false").equals("true");
+    		boolean noConsole = System.console() == null;
+	        if (isMsWindows || forceSwing || noConsole) {
+	        	backendType = BackendType.SWING;
+	        } else {
+	        	backendType = BackendType.XTERM;
+	        }
+    	}
+    	
         switch (backendType) {
         case SWING:
             backend = new SwingBackend(this);


### PR DESCRIPTION
I currently have to change the code every time I hit 'run' in eclipse or 'make run' in a terminal.
The backend guessing is currently done at the client level.

This patch would let the TApplication itself decide which backend is the best suited one at the given tiime and use it if no backend is specified.

The code will check: if jexer.Swing is "true", if we are on Windows, if a Console is available.

I guess it could check if we are in a headless mode, too, but without a Console I don't think it will do any good.

I don't know why some Demos set Swing on MacOS-X? This code does not (easy to change).